### PR TITLE
Reduce README noise by centralizing verification note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Developer recruiting is a specialized discipline. Generic recruiting tools often
 - [Research and Reports](#research-and-reports)
 - [Glossaries and References](#glossaries-and-references)
 - [Conferences and Events](#conferences-and-events)
+- [Last Verified](#last-verified)
 
 ## Start Here
 
@@ -45,254 +46,257 @@ Start with Applicant Tracking Systems and CRM and Outreach, then benchmark proce
 
 *Platforms for finding and reaching out to developer candidates.*
 
-- [LinkedIn Recruiter](https://www.linkedin.com/talent/hire) - Sourcing platform with developer-focused search filters by skills, company, and experience. *(Last verified: 2026-02).*
-- [daily.dev Recruiter](https://recruiter.daily.dev) - Developer sourcing platform using behavioral signals and opt-in candidate introductions. *(Last verified: 2026-02).*
-- [SeekOut](https://seekout.com) - Talent search tool that aggregates technical profile data from multiple public sources. *(Last verified: 2026-02).*
-- [hireEZ](https://hireez.com) - Sourcing platform with Boolean search across open web profiles. *(Last verified: 2026-02).*
-- [Hired](https://hired.com) - Hiring marketplace where candidates set expectations and companies send interview requests. *(Last verified: 2026-02).*
-- [Toptal](https://www.toptal.com) - Freelance network for contract and full-time developer roles. *(Last verified: 2026-02).*
-- [Turing](https://www.turing.com) - Platform for sourcing remote software engineers. *(Last verified: 2026-02).*
-- [Wellfound](https://wellfound.com) - Startup job marketplace with salary and equity details on many postings. *(Last verified: 2026-02).*
-- [Stack Overflow Talent](https://stackoverflow.co/talent) - Recruiting and employer branding products for the Stack Overflow audience. *(Last verified: 2026-02).*
-- [Gun.io](https://gun.io) - Freelance marketplace focused on software engineers. *(Last verified: 2026-02).*
-- [Arc.dev](https://arc.dev) - Remote hiring service for developer roles with screening and assessment features. *(Last verified: 2026-02).*
-- [Dice](https://www.dice.com) - Tech job board and candidate database for software and IT roles. *(Last verified: 2026-02).*
+- [LinkedIn Recruiter](https://www.linkedin.com/talent/hire) - Sourcing platform with developer-focused search filters by skills, company, and experience.
+- [daily.dev Recruiter](https://recruiter.daily.dev) - Developer sourcing platform using behavioral signals and opt-in candidate introductions.
+- [SeekOut](https://seekout.com) - Talent search tool that aggregates technical profile data from multiple public sources.
+- [hireEZ](https://hireez.com) - Sourcing platform with Boolean search across open web profiles.
+- [Hired](https://hired.com) - Hiring marketplace where candidates set expectations and companies send interview requests.
+- [Toptal](https://www.toptal.com) - Freelance network for contract and full-time developer roles.
+- [Turing](https://www.turing.com) - Platform for sourcing remote software engineers.
+- [Wellfound](https://wellfound.com) - Startup job marketplace with salary and equity details on many postings.
+- [Stack Overflow Talent](https://stackoverflow.co/talent) - Recruiting and employer branding products for the Stack Overflow audience.
+- [Gun.io](https://gun.io) - Freelance marketplace focused on software engineers.
+- [Arc.dev](https://arc.dev) - Remote hiring service for developer roles with screening and assessment features.
+- [Dice](https://www.dice.com) - Tech job board and candidate database for software and IT roles.
 
 ## Applicant Tracking Systems
 
 *ATS platforms commonly used for developer hiring pipelines.*
 
-- [Greenhouse](https://www.greenhouse.com) - ATS with scorecards, interview plans, and hiring analytics. *(Last verified: 2026-02).*
-- [Lever](https://www.lever.co) - ATS and CRM platform for pipeline management and team collaboration. *(Last verified: 2026-02).*
-- [Ashby](https://www.ashby.com) - Recruiting suite that combines ATS, scheduling, analytics, and CRM features. *(Last verified: 2026-02).*
-- [Workday Recruiting](https://www.workday.com/en-ca/applications/human-capital-management/recruiting.html) - Recruiting module in the Workday HCM product suite. *(Last verified: 2026-02).*
-- [Teamtailor](https://www.teamtailor.com) - ATS with career site tools and employer branding features. *(Last verified: 2026-02).*
-- [BambooHR](https://www.bamboohr.com) - HR system with applicant tracking features for growing teams. *(Last verified: 2026-02).*
-- [Recruitee](https://recruitee.com) - Recruiting software for pipeline management and collaborative hiring. *(Last verified: 2026-02).*
-- [Breezy HR](https://breezy.hr) - ATS with visual pipeline management and workflow automation. *(Last verified: 2026-02).*
-- [Pinpoint](https://pinpointhq.com) - ATS with analytics and employer branding capabilities. *(Last verified: 2026-02).*
-- [Comeet](https://www.comeet.com) - Recruiting software with interview, collaboration, and offer workflows. *(Last verified: 2026-02).*
+- [Greenhouse](https://www.greenhouse.com) - ATS with scorecards, interview plans, and hiring analytics.
+- [Lever](https://www.lever.co) - ATS and CRM platform for pipeline management and team collaboration.
+- [Ashby](https://www.ashby.com) - Recruiting suite that combines ATS, scheduling, analytics, and CRM features.
+- [Workday Recruiting](https://www.workday.com/en-ca/applications/human-capital-management/recruiting.html) - Recruiting module in the Workday HCM product suite.
+- [Teamtailor](https://www.teamtailor.com) - ATS with career site tools and employer branding features.
+- [BambooHR](https://www.bamboohr.com) - HR system with applicant tracking features for growing teams.
+- [Recruitee](https://recruitee.com) - Recruiting software for pipeline management and collaborative hiring.
+- [Breezy HR](https://breezy.hr) - ATS with visual pipeline management and workflow automation.
+- [Pinpoint](https://pinpointhq.com) - ATS with analytics and employer branding capabilities.
+- [Comeet](https://www.comeet.com) - Recruiting software with interview, collaboration, and offer workflows.
 
 ## Technical Assessment
 
 *Platforms for evaluating developer coding skills and technical ability.*
 
-- [HackerRank](https://www.hackerrank.com) - Technical assessment platform with coding tests across many programming languages. *(Last verified: 2026-02).*
-- [Codility](https://www.codility.com) - Coding test platform with timed tasks and anti-cheating controls. *(Last verified: 2026-02).*
-- [CodeSignal](https://codesignal.com) - Assessment tool using coding evaluations and role-based tests. *(Last verified: 2026-02).*
-- [LeetCode](https://leetcode.com) - Practice site for coding interview problems and algorithm fundamentals. *(Last verified: 2026-02).*
-- [CoderPad](https://coderpad.io) - Live coding interview environment with multi-language support. *(Last verified: 2026-02).*
-- [TestGorilla](https://www.testgorilla.com) - Pre-employment testing suite with coding and general aptitude assessments. *(Last verified: 2026-02).*
-- [Qualified](https://www.qualified.io) - Technical assessment tool built around project-style coding challenges. *(Last verified: 2026-02).*
-- [Coderbyte](https://coderbyte.com) - Coding challenge library and assessment platform for technical screening. *(Last verified: 2026-02).*
-- [Devskiller](https://devskiller.com) - Assessment platform using task-based coding exercises. *(Last verified: 2026-02).*
-- [Exercism](https://exercism.org) - Free coding practice site with mentor feedback. *(Last verified: 2026-02).*
-- [Skills Checklist Builder by daily.dev](https://recruiter.daily.dev/toolkit/skills-checklist) - Free checklist builder for evaluating role-specific technical skills. *(Last verified: 2026-02).*
+- [HackerRank](https://www.hackerrank.com) - Technical assessment platform with coding tests across many programming languages.
+- [Codility](https://www.codility.com) - Coding test platform with timed tasks and anti-cheating controls.
+- [CodeSignal](https://codesignal.com) - Assessment tool using coding evaluations and role-based tests.
+- [LeetCode](https://leetcode.com) - Practice site for coding interview problems and algorithm fundamentals.
+- [CoderPad](https://coderpad.io) - Live coding interview environment with multi-language support.
+- [TestGorilla](https://www.testgorilla.com) - Pre-employment testing suite with coding and general aptitude assessments.
+- [Qualified](https://www.qualified.io) - Technical assessment tool built around project-style coding challenges.
+- [Coderbyte](https://coderbyte.com) - Coding challenge library and assessment platform for technical screening.
+- [Devskiller](https://devskiller.com) - Assessment platform using task-based coding exercises.
+- [Exercism](https://exercism.org) - Free coding practice site with mentor feedback.
+- [Skills Checklist Builder by daily.dev](https://recruiter.daily.dev/toolkit/skills-checklist) - Free checklist builder for evaluating role-specific technical skills.
 
 ## Job Boards for Developers
 
 *Job boards where developers actively look for opportunities.*
 
-- [We Work Remotely](https://weworkremotely.com) - Remote job board with software engineering categories. *(Last verified: 2026-02).*
-- [RemoteOK](https://remoteok.com) - Remote job aggregator with developer and engineering filters. *(Last verified: 2026-02).*
-- [Hacker News: Who is Hiring](https://news.ycombinator.com/submitted?id=whoishiring) - Monthly hiring thread used by startups and technical teams. *(Last verified: 2026-02).*
-- [Key Values](https://www.keyvalues.com) - Job board where candidates filter companies by stated engineering culture values. *(Last verified: 2026-02).*
-- [Otta](https://otta.com) - Job board focused on startup and scale-up tech roles. *(Last verified: 2026-02).*
-- [Relocate.me](https://relocate.me) - Tech job board with relocation and visa support details. *(Last verified: 2026-02).*
-- [Working Nomads](https://www.workingnomads.com/jobs) - Remote job board with engineering and product categories. *(Last verified: 2026-02).*
-- [4 Day Week](https://4dayweek.io) - Job board for companies offering four-day work schedules. *(Last verified: 2026-02).*
-- [dev.to Listings](https://dev.to/listings) - Job listings posted through the DEV community platform. *(Last verified: 2026-02).*
-- [LinkedIn Jobs](https://www.linkedin.com/jobs) - Job marketplace with broad filters for technical roles. *(Last verified: 2026-02).*
+- [We Work Remotely](https://weworkremotely.com) - Remote job board with software engineering categories.
+- [RemoteOK](https://remoteok.com) - Remote job aggregator with developer and engineering filters.
+- [Hacker News: Who is Hiring](https://news.ycombinator.com/submitted?id=whoishiring) - Monthly hiring thread used by startups and technical teams.
+- [Key Values](https://www.keyvalues.com) - Job board where candidates filter companies by stated engineering culture values.
+- [Otta](https://otta.com) - Job board focused on startup and scale-up tech roles.
+- [Relocate.me](https://relocate.me) - Tech job board with relocation and visa support details.
+- [Working Nomads](https://www.workingnomads.com/jobs) - Remote job board with engineering and product categories.
+- [4 Day Week](https://4dayweek.io) - Job board for companies offering four-day work schedules.
+- [dev.to Listings](https://dev.to/listings) - Job listings posted through the DEV community platform.
+- [LinkedIn Jobs](https://www.linkedin.com/jobs) - Job marketplace with broad filters for technical roles.
 
 ## CRM and Outreach
 
 *Tools for managing candidate relationships and recruitment outreach.*
 
-- [Gem](https://www.gem.com) - Recruiting CRM for outreach campaigns, analytics, and ATS syncing. *(Last verified: 2026-02).*
-- [Fetcher](https://fetcher.ai) - Sourcing and outreach tool with automation and response tracking. *(Last verified: 2026-02).*
-- [Loxo](https://loxo.co) - Recruiting CRM with sourcing and outreach automation tools. *(Last verified: 2026-02).*
-- [Hireflow](https://www.hireflow.ai) - Outreach tool for generating candidate email drafts from role and profile data. *(Last verified: 2026-02).*
-- [Leonar](https://www.leonar.app) - Recruiting CRM for multi-channel outreach and pipeline tracking. *(Last verified: 2026-02).*
-- [Recruiterflow](https://recruiterflow.com) - CRM and ATS platform built for recruiting agencies. *(Last verified: 2026-02).*
-- [Humanly](https://humanly.io) - Conversational screening and scheduling tool for early-stage candidate workflows. *(Last verified: 2026-02).*
-- [Beamery](https://beamery.com) - Talent CRM for candidate engagement and workforce planning. *(Last verified: 2026-02).*
-- [Eightfold](https://eightfold.ai) - Talent intelligence system for matching and mobility workflows. *(Last verified: 2026-02).*
+- [Gem](https://www.gem.com) - Recruiting CRM for outreach campaigns, analytics, and ATS syncing.
+- [Fetcher](https://fetcher.ai) - Sourcing and outreach tool with automation and response tracking.
+- [Loxo](https://loxo.co) - Recruiting CRM with sourcing and outreach automation tools.
+- [Hireflow](https://www.hireflow.ai) - Outreach tool for generating candidate email drafts from role and profile data.
+- [Leonar](https://www.leonar.app) - Recruiting CRM for multi-channel outreach and pipeline tracking.
+- [Recruiterflow](https://recruiterflow.com) - CRM and ATS platform built for recruiting agencies.
+- [Humanly](https://humanly.io) - Conversational screening and scheduling tool for early-stage candidate workflows.
+- [Beamery](https://beamery.com) - Talent CRM for candidate engagement and workforce planning.
+- [Eightfold](https://eightfold.ai) - Talent intelligence system for matching and mobility workflows.
 
 ## Interview Platforms
 
 *Tools for conducting and managing technical interviews.*
 
-- [Interviewing.io](https://interviewing.io) - Mock interview service with anonymous sessions and hiring pathways. *(Last verified: 2026-02).*
-- [Karat](https://karat.com) - Interview service that provides trained interviewers for technical assessments. *(Last verified: 2026-02).*
-- [BrightHire](https://brighthire.com) - Interview recording and analysis tool for hiring teams. *(Last verified: 2026-02).*
-- [Metaview](https://metaview.ai) - Interview note-taking tool that generates structured summaries. *(Last verified: 2026-02).*
-- [HireVue](https://www.hirevue.com) - Video interviewing platform with live and on-demand interview formats. *(Last verified: 2026-02).*
-- [Willo](https://www.willo.video) - Asynchronous video interview tool for distributed hiring. *(Last verified: 2026-02).*
-- [Pillar](https://www.pillar.hr) - Interview support tool with guidance, notes, and evidence tracking. *(Last verified: 2026-02).*
-- [Interview Questions Hub by daily.dev](https://recruiter.daily.dev/toolkit/interview-questions) - Free library of technical interview questions by role and stack. *(Last verified: 2026-02).*
+- [Interviewing.io](https://interviewing.io) - Mock interview service with anonymous sessions and hiring pathways.
+- [Karat](https://karat.com) - Interview service that provides trained interviewers for technical assessments.
+- [BrightHire](https://brighthire.com) - Interview recording and analysis tool for hiring teams.
+- [Metaview](https://metaview.ai) - Interview note-taking tool that generates structured summaries.
+- [HireVue](https://www.hirevue.com) - Video interviewing platform with live and on-demand interview formats.
+- [Willo](https://www.willo.video) - Asynchronous video interview tool for distributed hiring.
+- [Pillar](https://www.pillar.hr) - Interview support tool with guidance, notes, and evidence tracking.
+- [Interview Questions Hub by daily.dev](https://recruiter.daily.dev/toolkit/interview-questions) - Free library of technical interview questions by role and stack.
 
 ## AI Recruiting Tools
 
 *Tools that use AI for sourcing, screening, and hiring workflows.*
 
-- [Juicebox](https://juicebox.ai) - Candidate search tool using natural-language queries. *(Last verified: 2026-02).*
-- [HireLogic](https://hirelogic.com) - Interview analysis tool with AI-based scoring and feedback summaries. *(Last verified: 2026-02).*
-- [Paradox](https://www.paradox.ai) - Conversational recruiting assistant for screening and scheduling workflows. *(Last verified: 2026-02).*
-- [Findem](https://www.findem.ai) - Talent data system that combines profile signals from multiple sources. *(Last verified: 2026-02).*
-- [Textio](https://textio.com) - Writing assistant for job posts and recruiting communication. *(Last verified: 2026-02).*
-- [Arya by Leoforce](https://leoforce.com) - Sourcing platform that ranks candidates using model-based matching. *(Last verified: 2026-02).*
-- [Manatal](https://www.manatal.com) - ATS with candidate recommendations and enrichment features. *(Last verified: 2026-02).*
-- [Phenom](https://www.phenom.com) - Talent experience suite with automation for high-volume recruiting. *(Last verified: 2026-02).*
-- [Entelo](https://www.entelo.com) - Sourcing platform with predictive candidate matching. *(Last verified: 2026-02).*
+- [Juicebox](https://juicebox.ai) - Candidate search tool using natural-language queries.
+- [HireLogic](https://hirelogic.com) - Interview analysis tool with AI-based scoring and feedback summaries.
+- [Paradox](https://www.paradox.ai) - Conversational recruiting assistant for screening and scheduling workflows.
+- [Findem](https://www.findem.ai) - Talent data system that combines profile signals from multiple sources.
+- [Textio](https://textio.com) - Writing assistant for job posts and recruiting communication.
+- [Arya by Leoforce](https://leoforce.com) - Sourcing platform that ranks candidates using model-based matching.
+- [Manatal](https://www.manatal.com) - ATS with candidate recommendations and enrichment features.
+- [Phenom](https://www.phenom.com) - Talent experience suite with automation for high-volume recruiting.
+- [Entelo](https://www.entelo.com) - Sourcing platform with predictive candidate matching.
 
 ## Job Description Tools
 
 *Tools for writing and optimizing developer job descriptions.*
 
-- [Job Description Generator by daily.dev](https://recruiter.daily.dev/toolkit/job-description-generator) - Free job description template generator by role and stack. *(Last verified: 2026-02).*
-- [Gender Decoder](https://gender-decoder.katmatfield.com) - Tool for checking job posts for gender-coded wording. *(Last verified: 2026-02).*
-- [Datapeople](https://www.datapeople.io) - Job description analysis tool with language feedback and benchmarks. *(Last verified: 2026-02).*
-- [Ongig](https://www.ongig.com) - Job description text analysis tool for readability and bias checks. *(Last verified: 2026-02).*
-- [Applied](https://www.beapplied.com) - Hiring workflow tool with blind screening and structured evaluation. *(Last verified: 2026-02).*
-- [TalVista](https://talvista.com) - Inclusive hiring tool with job post and interview process features. *(Last verified: 2026-02).*
-- [Hemingway Editor](https://hemingwayapp.com) - Writing editor that flags complex sentences and passive voice. *(Last verified: 2026-02).*
+- [Job Description Generator by daily.dev](https://recruiter.daily.dev/toolkit/job-description-generator) - Free job description template generator by role and stack.
+- [Gender Decoder](https://gender-decoder.katmatfield.com) - Tool for checking job posts for gender-coded wording.
+- [Datapeople](https://www.datapeople.io) - Job description analysis tool with language feedback and benchmarks.
+- [Ongig](https://www.ongig.com) - Job description text analysis tool for readability and bias checks.
+- [Applied](https://www.beapplied.com) - Hiring workflow tool with blind screening and structured evaluation.
+- [TalVista](https://talvista.com) - Inclusive hiring tool with job post and interview process features.
+- [Hemingway Editor](https://hemingwayapp.com) - Writing editor that flags complex sentences and passive voice.
 
 ## Employer Branding
 
 *Tools and strategies for building a strong employer brand among developers.*
 
-- [Glassdoor for Employers](https://www.glassdoor.com/employers) - Employer profile and branding tools connected to reviews, salaries, and interview data. *(Last verified: 2026-02).*
-- [The Muse](https://www.themuse.com/employers) - Employer branding service with company profiles and content publishing. *(Last verified: 2026-02).*
-- [Builtin](https://builtin.com) - Employer branding and job advertising network focused on tech markets. *(Last verified: 2026-02).*
-- [RepVue](https://www.repvue.com) - Employer ratings site with culture and compensation feedback. *(Last verified: 2026-02).*
-- [Comparably](https://www.comparably.com) - Company comparison site for workplace and compensation benchmarks. *(Last verified: 2026-02).*
-- [Stack Overflow Employer Branding](https://stackoverflow.co/advertising/use-cases/employer-branding-teams/) - Employer branding and ad products for Stack Overflow. *(Last verified: 2026-02).*
+- [Glassdoor for Employers](https://www.glassdoor.com/employers) - Employer profile and branding tools connected to reviews, salaries, and interview data.
+- [The Muse](https://www.themuse.com/employers) - Employer branding service with company profiles and content publishing.
+- [Builtin](https://builtin.com) - Employer branding and job advertising network focused on tech markets.
+- [RepVue](https://www.repvue.com) - Employer ratings site with culture and compensation feedback.
+- [Comparably](https://www.comparably.com) - Company comparison site for workplace and compensation benchmarks.
+- [Stack Overflow Employer Branding](https://stackoverflow.co/advertising/use-cases/employer-branding-teams/) - Employer branding and ad products for Stack Overflow.
 
 ## Developer Compensation
 
 *Salary data and benchmarking tools for tech roles.*
 
-- [Levels.fyi](https://www.levels.fyi) - Compensation database with level and location breakdowns for tech roles. *(Last verified: 2026-02).*
-- [Glassdoor Salaries](https://www.glassdoor.com/Salaries) - Salary database sourced from employee reports. *(Last verified: 2026-02).*
-- [Payscale](https://www.payscale.com) - Compensation software for salary benchmarking and market pricing. *(Last verified: 2026-02).*
-- [Pave](https://www.pave.com) - Compensation benchmarking tool connected to HR system data. *(Last verified: 2026-02).*
-- [Carta Total Comp](https://carta.com/total-comp) - Startup compensation and equity benchmarking tools. *(Last verified: 2026-02).*
-- [Ravio](https://ravio.com) - Compensation benchmarking service focused on European markets. *(Last verified: 2026-02).*
-- [Comptryx](https://www.comptryx.com) - Compensation benchmarking database for technical roles across global markets. *(Last verified: 2026-02).*
-- [OpenComp](https://www.opencomp.com) - Compensation planning software with market benchmarks and pay equity analysis. *(Last verified: 2026-02).*
+- [Levels.fyi](https://www.levels.fyi) - Compensation database with level and location breakdowns for tech roles.
+- [Glassdoor Salaries](https://www.glassdoor.com/Salaries) - Salary database sourced from employee reports.
+- [Payscale](https://www.payscale.com) - Compensation software for salary benchmarking and market pricing.
+- [Pave](https://www.pave.com) - Compensation benchmarking tool connected to HR system data.
+- [Carta Total Comp](https://carta.com/total-comp) - Startup compensation and equity benchmarking tools.
+- [Ravio](https://ravio.com) - Compensation benchmarking service focused on European markets.
+- [Comptryx](https://www.comptryx.com) - Compensation benchmarking database for technical roles across global markets.
+- [OpenComp](https://www.opencomp.com) - Compensation planning software with market benchmarks and pay equity analysis.
 
 ## Diversity and Inclusion
 
 *Tools and resources for building diverse engineering teams.*
 
-- [Mathison](https://www.mathison.io) - Diversity recruiting toolset with sourcing, analytics, and training modules. *(Last verified: 2026-02).*
-- [Jopwell](https://www.jopwell.com) - Career network for Black, Latinx, and Native American professionals. *(Last verified: 2026-02).*
-- [PowerToFly](https://powertofly.com) - Career network connecting underrepresented talent with employers. *(Last verified: 2026-02).*
-- [Hire Tech Ladies](https://www.hiretechladies.com) - Job board and community for women and non-binary professionals in tech. *(Last verified: 2026-02).*
-- [Diversio](https://diversio.com) - DEI analytics tool for measuring inclusion metrics. *(Last verified: 2026-02).*
-- [Project Include](https://projectinclude.org) - Non-profit organization publishing inclusion guidance for tech teams. *(Last verified: 2026-02).*
-- [Code2040](https://www.code2040.org) - Non-profit organization supporting Black and Latinx technologists. *(Last verified: 2026-02).*
+- [Mathison](https://www.mathison.io) - Diversity recruiting toolset with sourcing, analytics, and training modules.
+- [Jopwell](https://www.jopwell.com) - Career network for Black, Latinx, and Native American professionals.
+- [PowerToFly](https://powertofly.com) - Career network connecting underrepresented talent with employers.
+- [Hire Tech Ladies](https://www.hiretechladies.com) - Job board and community for women and non-binary professionals in tech.
+- [Diversio](https://diversio.com) - DEI analytics tool for measuring inclusion metrics.
+- [Project Include](https://projectinclude.org) - Non-profit organization publishing inclusion guidance for tech teams.
+- [Code2040](https://www.code2040.org) - Non-profit organization supporting Black and Latinx technologists.
 
 ## Open Source Recruiting Tools
 
 *Free and open source tools for technical recruiting.*
 
-- [OpenCATS](https://www.opencats.org) - Open-source applicant tracking system for candidate and job management. *(Last verified: 2026-02).*
-- [OpenResume](https://www.open-resume.com) - Open-source resume builder with ATS-focused formatting. *(Last verified: 2026-02).*
-- [Freshteam](https://www.freshworks.com/hrms/applicant-tracking) - ATS with a free tier for basic applicant tracking. *(Last verified: 2026-02).*
+- [OpenCATS](https://www.opencats.org) - Open-source applicant tracking system for candidate and job management.
+- [OpenResume](https://www.open-resume.com) - Open-source resume builder with ATS-focused formatting.
+- [Freshteam](https://www.freshworks.com/hrms/applicant-tracking) - ATS with a free tier for basic applicant tracking.
 
 ## Newsletters
 
 *Newsletters covering tech recruiting trends and strategies.*
 
-- [The 1% Tech Recruiter by daily.dev](https://recruiter.daily.dev/newsletter) - Weekly newsletter on developer recruiting trends and data. *(Last verified: 2026-02).*
-- [Recruiting Brainfood](https://recruitingbrainfood.com) - Weekly newsletter on recruiting tools, operations, and market updates. *(Last verified: 2026-02).*
-- [The Pragmatic Engineer](https://newsletter.pragmaticengineer.com) - Newsletter covering engineering leadership, hiring, and compensation topics. *(Last verified: 2026-02).*
-- [Recruiting Daily](https://recruitingdaily.com/recruitingdaily-newsletter/) - Newsletter on sourcing, recruiting operations, and talent technology. *(Last verified: 2026-02).*
-- [Hacking HR](https://www.hackinghr.com) - Newsletter covering HR, people analytics, and workforce topics. *(Last verified: 2026-02).*
-- [People Managing People](https://peoplemanagingpeople.com/newsletter) - Weekly newsletter on hiring and people management. *(Last verified: 2026-02).*
-- [Chad & Cheese](https://www.chadcheese.com/subscribe) - Newsletter with commentary on recruiting tools and HR technology. *(Last verified: 2026-02).*
+- [The 1% Tech Recruiter by daily.dev](https://recruiter.daily.dev/newsletter) - Weekly newsletter on developer recruiting trends and data.
+- [Recruiting Brainfood](https://recruitingbrainfood.com) - Weekly newsletter on recruiting tools, operations, and market updates.
+- [The Pragmatic Engineer](https://newsletter.pragmaticengineer.com) - Newsletter covering engineering leadership, hiring, and compensation topics.
+- [Recruiting Daily](https://recruitingdaily.com/recruitingdaily-newsletter/) - Newsletter on sourcing, recruiting operations, and talent technology.
+- [Hacking HR](https://www.hackinghr.com) - Newsletter covering HR, people analytics, and workforce topics.
+- [People Managing People](https://peoplemanagingpeople.com/newsletter) - Weekly newsletter on hiring and people management.
+- [Chad & Cheese](https://www.chadcheese.com/subscribe) - Newsletter with commentary on recruiting tools and HR technology.
 
 ## Communities
 
 *Communities where tech recruiters learn, share, and network.*
 
-- [Recruiting Brainfood Community](https://brainfood.social) - Recruiter community for sharing tools, tactics, and discussion. *(Last verified: 2026-02).*
-- [r/recruiting](https://www.reddit.com/r/recruiting/) - Reddit forum for recruiting questions and peer discussion. *(Last verified: 2026-02).*
-- [SourceCon Community](https://newsletter.sourcecon.com) - Community and event network focused on sourcing and recruiting. *(Last verified: 2026-02).*
-- [RecOps Collective](https://www.recops.co) - Community focused on recruiting operations systems and workflows. *(Last verified: 2026-02).*
-- [Hiring Academy by daily.dev](https://recruiter.daily.dev/academy) - Learning hub for developer hiring guides and frameworks. *(Last verified: 2026-02).*
+- [Recruiting Brainfood Community](https://brainfood.social) - Recruiter community for sharing tools, tactics, and discussion.
+- [r/recruiting](https://www.reddit.com/r/recruiting/) - Reddit forum for recruiting questions and peer discussion.
+- [SourceCon Community](https://newsletter.sourcecon.com) - Community and event network focused on sourcing and recruiting.
+- [RecOps Collective](https://www.recops.co) - Community focused on recruiting operations systems and workflows.
+- [Hiring Academy by daily.dev](https://recruiter.daily.dev/academy) - Learning hub for developer hiring guides and frameworks.
 
 ## Podcasts
 
 *Podcasts about technical recruiting and talent acquisition.*
 
-- [Talk Talent to Me](https://www.hired.com/blog/podcast) - Podcast interviews with recruiting and talent leaders. *(Last verified: 2026-02).*
-- [The Recruitment Hackers](https://www.therecruitmenthackers.com) - Podcast on recruiting operations, sourcing, and candidate experience. *(Last verified: 2026-02).*
-- [Chad & Cheese Podcast](https://www.chadcheese.com) - Podcast covering recruiting tools and HR technology commentary. *(Last verified: 2026-02).*
-- [RecTech Podcast](https://www.rectechpodcast.com) - Podcast focused on recruiting technology and vendor trends. *(Last verified: 2026-02).*
-- [The Recruiting Future Podcast](https://recruitingfuture.com/podcast/) - Podcast on hiring strategy, automation, and talent operations. *(Last verified: 2026-02).*
-- [People Solving Problems](https://www.peoplesolvingproblems.com) - Podcast with engineering leaders discussing hiring and team building. *(Last verified: 2026-02).*
+- [Talk Talent to Me](https://www.hired.com/blog/podcast) - Podcast interviews with recruiting and talent leaders.
+- [The Recruitment Hackers](https://www.therecruitmenthackers.com) - Podcast on recruiting operations, sourcing, and candidate experience.
+- [Chad & Cheese Podcast](https://www.chadcheese.com) - Podcast covering recruiting tools and HR technology commentary.
+- [RecTech Podcast](https://www.rectechpodcast.com) - Podcast focused on recruiting technology and vendor trends.
+- [The Recruiting Future Podcast](https://recruitingfuture.com/podcast/) - Podcast on hiring strategy, automation, and talent operations.
+- [People Solving Problems](https://www.peoplesolvingproblems.com) - Podcast with engineering leaders discussing hiring and team building.
 
 ## Books
 
 *Essential reading for developer recruiters.*
 
-- [Who: The A Method for Hiring](https://whothebook.com) - Book on structured hiring by Geoff Smart and Randy Street. *(Last verified: 2026-02).*
-- [Work Rules!](https://www.workrules.net) - Book on hiring and people operations practices at Google. *(Last verified: 2026-02).*
-- [Full Stack Recruiter](https://fullstackrecruiter.net) - Book covering sourcing tools and recruiter workflows by Jan Tegze. *(Last verified: 2026-02).*
-- [Smart and Gets Things Done](https://www.joelonsoftware.com/2007/06/05/smart-and-gets-things-done/) - Book on hiring software developers by Joel Spolsky. *(Last verified: 2026-02).*
-- [The Best Team Wins](https://www.amazon.com/Best-Team-Wins-Performance-Based-Assessment/dp/1633692604) - Book on performance-based interviewing and candidate evaluation. *(Last verified: 2026-02).*
-- [Hiring for Attitude](https://www.amazon.com/Hiring-Attitude-Innovative-Approach-Employees/dp/0071785868) - Book on evaluating attitude and cultural fit in hiring. *(Last verified: 2026-02).*
-- [Talent Magnet](https://www.amazon.com/Talent-Magnet-Attract-Keep-Best/dp/1626346410) - Book on leadership approaches for attracting and retaining talent. *(Last verified: 2026-02).*
+- [Who: The A Method for Hiring](https://whothebook.com) - Book on structured hiring by Geoff Smart and Randy Street.
+- [Work Rules!](https://www.workrules.net) - Book on hiring and people operations practices at Google.
+- [Full Stack Recruiter](https://fullstackrecruiter.net) - Book covering sourcing tools and recruiter workflows by Jan Tegze.
+- [Smart and Gets Things Done](https://www.joelonsoftware.com/2007/06/05/smart-and-gets-things-done/) - Book on hiring software developers by Joel Spolsky.
+- [The Best Team Wins](https://www.amazon.com/Best-Team-Wins-Performance-Based-Assessment/dp/1633692604) - Book on performance-based interviewing and candidate evaluation.
+- [Hiring for Attitude](https://www.amazon.com/Hiring-Attitude-Innovative-Approach-Employees/dp/0071785868) - Book on evaluating attitude and cultural fit in hiring.
+- [Talent Magnet](https://www.amazon.com/Talent-Magnet-Attract-Keep-Best/dp/1626346410) - Book on leadership approaches for attracting and retaining talent.
 
 ## Blogs and Publications
 
 *Regularly updated blogs about developer hiring.*
 
-- [Recruiting Resources by daily.dev](https://recruiter.daily.dev/resources) - Articles and guides on developer recruiting practices. *(Last verified: 2026-02).*
-- [LinkedIn Talent Blog](https://www.linkedin.com/business/talent/blog) - Blog with hiring data, trends, and recruiting guidance. *(Last verified: 2026-02).*
-- [The Pragmatic Engineer Blog](https://blog.pragmaticengineer.com) - Blog on engineering leadership, hiring, and compensation. *(Last verified: 2026-02).*
-- [Greenhouse Blog](https://www.greenhouse.com/blog) - Blog on interviewing, structured hiring, and recruiting operations. *(Last verified: 2026-02).*
-- [ERE.net](https://www.ere.net) - Recruiting news site with articles and commentary. *(Last verified: 2026-02).*
-- [Joel on Software](https://www.joelonsoftware.com) - Essays on software teams, hiring, and management. *(Last verified: 2026-02).*
-- [First Round Review](https://review.firstround.com) - Startup-focused articles on hiring and company building. *(Last verified: 2026-02).*
-- [Ashby Blog](https://www.ashbyhq.com/blog) - Blog on recruiting operations and hiring systems. *(Last verified: 2026-02).*
+- [Recruiting Resources by daily.dev](https://recruiter.daily.dev/resources) - Articles and guides on developer recruiting practices.
+- [LinkedIn Talent Blog](https://www.linkedin.com/business/talent/blog) - Blog with hiring data, trends, and recruiting guidance.
+- [The Pragmatic Engineer Blog](https://blog.pragmaticengineer.com) - Blog on engineering leadership, hiring, and compensation.
+- [Greenhouse Blog](https://www.greenhouse.com/blog) - Blog on interviewing, structured hiring, and recruiting operations.
+- [ERE.net](https://www.ere.net) - Recruiting news site with articles and commentary.
+- [Joel on Software](https://www.joelonsoftware.com) - Essays on software teams, hiring, and management.
+- [First Round Review](https://review.firstround.com) - Startup-focused articles on hiring and company building.
+- [Ashby Blog](https://www.ashbyhq.com/blog) - Blog on recruiting operations and hiring systems.
 
 ## Research and Reports
 
 *Industry research and data about developer hiring.*
 
-- [State of Developer Trust 2025 by daily.dev](https://recruiter.daily.dev/state-of-trust) - Report on developer behavior and recruiter trust. *(Last verified: 2026-02).*
-- [Stack Overflow Developer Survey](https://survey.stackoverflow.co) - Annual survey of developers on tools, work, and compensation. *(Last verified: 2026-02).*
-- [GitHub Octoverse](https://octoverse.github.com) - Annual report on open source activity and developer trends. *(Last verified: 2026-02).*
-- [Hired State of Tech Salaries](https://hired.com/state-of-tech-salaries) - Annual salary report for technical roles across markets. *(Last verified: 2026-02).*
-- [LinkedIn Global Talent Trends](https://business.linkedin.com/talent-solutions/global-talent-trends) - Annual report on hiring and workforce trends. *(Last verified: 2026-02).*
-- [HackerRank Developer Skills Report](https://www.hackerrank.com/research/developer-skills) - Annual report on developer skills and hiring needs. *(Last verified: 2026-02).*
-- [CodinGame Developer Survey](https://www.codingame.com/work/developer-survey) - Survey on developer preferences in hiring and technical assessment. *(Last verified: 2026-02).*
-- [DevSkiller IT Skills Report](https://devskiller.com/it-skills-report) - Report on developer skill trends based on assessment data. *(Last verified: 2026-02).*
+- [State of Developer Trust 2025 by daily.dev](https://recruiter.daily.dev/state-of-trust) - Report on developer behavior and recruiter trust.
+- [Stack Overflow Developer Survey](https://survey.stackoverflow.co) - Annual survey of developers on tools, work, and compensation.
+- [GitHub Octoverse](https://octoverse.github.com) - Annual report on open source activity and developer trends.
+- [Hired State of Tech Salaries](https://hired.com/state-of-tech-salaries) - Annual salary report for technical roles across markets.
+- [LinkedIn Global Talent Trends](https://business.linkedin.com/talent-solutions/global-talent-trends) - Annual report on hiring and workforce trends.
+- [HackerRank Developer Skills Report](https://www.hackerrank.com/research/developer-skills) - Annual report on developer skills and hiring needs.
+- [CodinGame Developer Survey](https://www.codingame.com/work/developer-survey) - Survey on developer preferences in hiring and technical assessment.
+- [DevSkiller IT Skills Report](https://devskiller.com/it-skills-report) - Report on developer skill trends based on assessment data.
 
 ## Glossaries and References
 
 *Reference materials for understanding tech recruiting terminology.*
 
-- [Tech Recruiting Glossary by daily.dev](https://recruiter.daily.dev/glossary) - Glossary of technology and recruiting terminology. *(Last verified: 2026-02).*
-- [GitHub Glossary](https://docs.github.com/en/get-started/learning-about-github/github-glossary) - Reference glossary of common GitHub terms. *(Last verified: 2026-02).*
-- [Stack Overflow Tags](https://stackoverflow.com/tags) - Tag directory for programming languages and developer tools. *(Last verified: 2026-02).*
-- [SHRM HR Glossary](https://www.shrm.org/topics-tools/tools/hr-glossary) - Reference glossary of HR and recruitment terms. *(Last verified: 2026-02).*
+- [Tech Recruiting Glossary by daily.dev](https://recruiter.daily.dev/glossary) - Glossary of technology and recruiting terminology.
+- [GitHub Glossary](https://docs.github.com/en/get-started/learning-about-github/github-glossary) - Reference glossary of common GitHub terms.
+- [Stack Overflow Tags](https://stackoverflow.com/tags) - Tag directory for programming languages and developer tools.
+- [SHRM HR Glossary](https://www.shrm.org/topics-tools/tools/hr-glossary) - Reference glossary of HR and recruitment terms.
 
 ## Conferences and Events
 
 *Industry events for technical recruiting professionals.*
 
-- [SourceCon](https://www.sourcecon.com) - Event focused on sourcing practices and recruiting tools. *(Last verified: 2026-02).*
-- [RecFest](https://recfest.com) - Recruiting event with sessions for talent teams. *(Last verified: 2026-02).*
-- [HR Technology Conference](https://www.hrtechnologyconference.com) - Conference on HR and recruiting technology platforms. *(Last verified: 2026-02).*
-- [Talent Connect by LinkedIn](https://www.linkedintalentconnect.com/) - LinkedIn event focused on hiring and workforce planning topics. *(Last verified: 2026-02).*
-- [Unleash World](https://www.unleash.ai) - Conference on HR technology, talent acquisition, and people analytics. *(Last verified: 2026-02).*
-- [SaaStr Annual](https://www.saastr.com/annual) - SaaS conference with sessions that include engineering hiring topics. *(Last verified: 2026-02).*
+- [SourceCon](https://www.sourcecon.com) - Event focused on sourcing practices and recruiting tools.
+- [RecFest](https://recfest.com) - Recruiting event with sessions for talent teams.
+- [HR Technology Conference](https://www.hrtechnologyconference.com) - Conference on HR and recruiting technology platforms.
+- [Talent Connect by LinkedIn](https://www.linkedintalentconnect.com/) - LinkedIn event focused on hiring and workforce planning topics.
+- [Unleash World](https://www.unleash.ai) - Conference on HR technology, talent acquisition, and people analytics.
+- [SaaStr Annual](https://www.saastr.com/annual) - SaaS conference with sessions that include engineering hiring topics.
 
 ## Contributing
 
 Please read the [contribution guidelines](contributing.md) before submitting a pull request.
 
+## Last Verified
+
+List links and descriptions were last verified in **2026-02**.


### PR DESCRIPTION
## Summary
- Remove per-entry "Last verified" annotations from README list items.
- Add one centralized `Last Verified` section at the end of README.
- Add `Last Verified` to the table of contents.

## Test plan
- [x] Confirm per-entry annotations are removed.
- [x] Confirm the centralized section is present and visible in TOC.
- [x] Confirm CI lint/check workflows pass.

Made with [Cursor](https://cursor.com)