### PR TITLE
Add security policy and contribution safety guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Security concerns (private reporting preferred)
+    url: https://github.com/dailydotdev/awesome-developer-recruiting/security/policy
+    about: Please use the Security tab for private vulnerability reporting when possible.
   - name: Contributor Code of Conduct
     url: https://github.com/dailydotdev/awesome-developer-recruiting/blob/main/code-of-conduct.md
     about: Please review expected behavior before participating.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,8 @@ Describe what changed and why it should be included.
 - [ ] I checked for duplicate entries.
 - [ ] Descriptions are concise, objective, and end with a period.
 - [ ] I verified links are valid and not broken.
+- [ ] I used canonical HTTPS URLs without shorteners, referral codes, or tracking parameters.
+- [ ] I disclosed any affiliation with the added/updated resource.
 - [ ] This pull request contains a single logical change.
 
 ## Additional Context

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+This repository is a curated list, not an application or package. Most security risks here are content risks (for example: malicious links, typo-squatted domains, deceptive redirects, or unsafe contribution patterns).
+
+## Supported Scope
+
+This policy applies to:
+
+- `README.md` entries and outbound links
+- Contribution workflows, issue templates, and automation in `.github/`
+- Any change that could mislead contributors or direct users to unsafe resources
+
+## How to Report a Security Concern
+
+Please avoid posting sensitive details in public issues.
+
+Preferred path:
+
+1. Open a private vulnerability report through the repository **Security** tab (GitHub private reporting).
+2. Include the affected entry/workflow, impact, and reproduction details.
+
+Fallback path (if private reporting is unavailable):
+
+1. Open a public issue with minimal details.
+2. Clearly mark it as a security concern.
+3. Do not include exploit instructions or sensitive data.
+
+## Response Expectations
+
+- Initial triage target: within 7 days
+- Status updates: at least every 7 days while the report is active
+- Fix timing: depends on severity and maintainer availability
+
+## Disclosure
+
+Please allow maintainers time to investigate and remediate before full public disclosure.

--- a/contributing.md
+++ b/contributing.md
@@ -17,6 +17,15 @@ Please ensure your pull request adheres to the following guidelines:
 - Make sure your text editor is set to remove trailing whitespace.
 - The pull request should include a clear title and a short note on why the resource belongs in this list.
 
+## Trust and Safety Checks
+
+Before submitting:
+
+- Use canonical HTTPS links (no shortened URLs, no tracking parameters).
+- Avoid links that immediately redirect through ad, affiliate, or unknown tracking domains.
+- If you are affiliated with a resource, disclose that in your PR description.
+- Flag suspicious or potentially malicious links using our security process in `SECURITY.md`.
+
 ## Updating Your Pull Request
 
 If the maintainers notice anything that needs to change before merging, we will ask you to edit your pull request. There is no need to open a new one. Please follow the suggestions in [this guide](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) on how to update a pull request.
@@ -54,7 +63,8 @@ For non-PR suggestions and maintenance tasks, use the issue templates in `.githu
 - General recruitment tools with no specific developer or tech focus.
 - Unmaintained, deprecated, or archived projects.
 - Resources behind full paywalls, unless there is a strong reason to include them.
-- Affiliate links or marketing content disguised as resources.
+- Affiliate links, referral links, or URL shorteners.
+- Marketing content disguised as neutral resources.
 - Duplicate entries or tools that replicate an existing entry without clear differentiation.
 
 Thanks for helping improve the list.


### PR DESCRIPTION
## Summary
- Add a repository `SECURITY.md` policy tailored to content and link-safety risks.
- Add Dependabot updates for GitHub Actions to keep workflow dependencies current.
- Tighten contributor intake by requiring canonical URL hygiene and affiliation disclosure in templates/guidelines.

## Test plan
- [x] Validate changed markdown/yaml files for lint diagnostics in editor.
- [x] Review diff to confirm only governance/safety files are included.
- [ ] Verify branch protection and private vulnerability reporting settings in GitHub UI.

Made with [Cursor](https://cursor.com)